### PR TITLE
specify encoding for perldoc

### DIFF
--- a/lib/String/Ident.pm
+++ b/lib/String/Ident.pm
@@ -30,6 +30,8 @@ sub cleanup {
 
 __END__
 
+=encoding utf8
+
 =head1 NAME
 
 String::Ident - clean-up string to be used as identifier and in URLs


### PR DESCRIPTION
I got following error when `perldoc String::Ident`.

```
    Around line 39:
        Non-ASCII character seen before =encoding in 'wœrlď!')'. Assuming
        UTF-8
```
