### PR TITLE
pass max-length, or turn it off altogether

### DIFF
--- a/README
+++ b/README
@@ -10,6 +10,9 @@ DESCRIPTION
 
 METHODS
   cleanup()
+    "cleanup" does the following things to convert your messy string into
+    something that you can use as an identifier:
+
         # replace unicode by ascii
         $text = unidecode($text);
 
@@ -28,8 +31,17 @@ METHODS
 
         # min length is set to 4 filled in by random letters
 
+    "cleanup" per default truncates the text to 30 chars. You can pass in
+    some other limit, or -1 to not truncate:
+
+      cleanup("some very long töxt Lorem ipsum dolor sit amet, consectetur adipiscing elit, ", 15);
+      # 'some-very-long-toxt-'
+
+      cleanup("some very long töxt Lorem ipsum dolor sit amet, consectetur adipiscing elit, ", -1);
+      # 'some-very-long-toxt-Lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit'
+
 AUTHOR
-    Jozef Kutej, `<jkutej at cpan.org>'
+    Jozef Kutej, "<jkutej at cpan.org>"
 
 CONTRIBUTORS
     The following people have contributed to the File::is by committing
@@ -37,12 +49,15 @@ CONTRIBUTORS
     suggesting useful advises, nitpicking, chatting on IRC or commenting on
     my blog (in no particular order):
 
-        Andrea Pavlovic
-        Syohei YOSHIDA
+    *   Andrea Pavlovic
+
+    *   Syohei YOSHIDA
+
+    *   Thomas Klausner, "<domm@plix.at>"
 
 THANKS
-    Thanks to VÖV - Verband Österreichischer Volkshochschulen for
-    sponsoring development of this module.
+    Thanks to VÖV - Verband Österreichischer Volkshochschulen
+    <http://www.vhs.or.at/> for sponsoring development of this module.
 
 LICENSE AND COPYRIGHT
     This program is free software; you can redistribute it and/or modify it

--- a/lib/String/Ident.pm
+++ b/lib/String/Ident.pm
@@ -9,7 +9,7 @@ our $VERSION = 0.02;
 use Text::Unidecode 'unidecode';
 
 sub cleanup {
-    my ($self, $text) = @_;
+    my ($self, $text, $maxlength) = @_;
 
     $text = '' unless defined($text);
     $text = unidecode($text);
@@ -17,7 +17,11 @@ sub cleanup {
     $text =~ s/--+/-/g;
     $text =~ s/-$//g;
     $text =~ s/^-//g;
-    $text = substr($text,0,30);
+
+    if (!$maxlength || $maxlength > 0) {
+        $maxlength ||= 30;
+        $text = substr($text,0,$maxlength);
+    }
     while (length($text) < 4) {
         $text .= chr(ord('a') + rand(ord('z') - ord('a') + 1));
     }
@@ -49,6 +53,8 @@ clean-up string to be used as identifier and in URLs
 
 =head2 cleanup()
 
+C<cleanup> does the following things to convert your messy string into something that you can use as an identifier:
+
     # replace unicode by ascii
     $text = unidecode($text);
 
@@ -67,6 +73,14 @@ clean-up string to be used as identifier and in URLs
 
     # min length is set to 4 filled in by random letters
 
+C<cleanup> per default truncates the text to 30 chars. You can pass in some other limit, or C<-1> to not truncate:
+
+  cleanup("some very long töxt Lorem ipsum dolor sit amet, consectetur adipiscing elit, ", 15);
+  # 'some-very-long-toxt-'
+
+  cleanup("some very long töxt Lorem ipsum dolor sit amet, consectetur adipiscing elit, ", -1);
+  # 'some-very-long-toxt-Lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit'
+
 =head1 AUTHOR
 
 Jozef Kutej, C<< <jkutej at cpan.org> >>
@@ -78,8 +92,15 @@ code, sending patches, reporting bugs, asking questions, suggesting useful
 advises, nitpicking, chatting on IRC or commenting on my blog (in no particular
 order):
 
-    Andrea Pavlovic
-    Syohei YOSHIDA
+=over
+
+=item * Andrea Pavlovic
+
+=item * Syohei YOSHIDA
+
+=item * Thomas Klausner, C<< <domm@plix.at> >>
+
+=back
 
 =head1 THANKS
 

--- a/t/01_String-Ident.t
+++ b/t/01_String-Ident.t
@@ -10,8 +10,31 @@ use Test::More;
 use_ok('String::Ident') or die;
 
 my $ident = String::Ident->cleanup('');
-is(length($ident),4, 'default min length 4');
-is(length(String::Ident->cleanup('x'x100)),30, 'default max length 30');
-is(String::Ident->cleanup('Hěλλo wœřľδ!'),'Hello-woerld', 'unidecode');
+is( length($ident), 4, 'default min length 4' );
+is( length( String::Ident->cleanup( 'x' x 100 ) ),
+    30, 'default max length 30' );
+is( String::Ident->cleanup('Hěλλo wœřľδ!'),
+    'Hello-woerld', 'unidecode' );
+
+is( length( String::Ident->cleanup( 'x' x 100, 42 ) ),
+    42, 'custom max length 42' );
+is( length( String::Ident->cleanup( 'x' x 100, -1 ) ),
+    100, 'do not truncate' );
+
+is( String::Ident->cleanup(
+        "some very long töxt Lorem ipsum dolor sit amet, consectetur adipiscing elit, ",
+        20
+    ),
+    'some-very-long-toxt-',
+    'docu truncate 20'
+);
+
+is( String::Ident->cleanup(
+        "some very long töxt Lorem ipsum dolor sit amet, consectetur adipiscing elit, ",
+        -1
+    ),
+    'some-very-long-toxt-Lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit',
+    'docu do not truncate'
+);
 
 done_testing();


### PR DESCRIPTION
Hi!

I don't like the hardcoded limit of 30 chars. This patch allows passing an explicit other limit, or -1 for no truncation.

btw, I think the interface could be improved a lot, by either ditching the unused object, or using it to store some settings (like maxlength)
